### PR TITLE
Extending `hosts` to also accept new `target_hosts` variable

### DIFF
--- a/playbooks/install.yaml
+++ b/playbooks/install.yaml
@@ -1,6 +1,6 @@
 ---
 - name: "Install Ironic on the target host."
-  hosts: target
+  hosts: "{{ target_hosts | default('target') }}"
   become: yes
   gather_facts: yes
   vars:


### PR DESCRIPTION
Many thanks for providing a single `install.yaml` playbook which installs `bifrost` in one go. Great work!

It seems the hosts are fixed to `target` in the playbook. Would it be possible to make the playbook work with other inventories by introducing a new variable `target_hosts` as in the PR? The proposed change should be backwards compatible.